### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,11 @@
 [*]
-charset      = utf-8
-indent_size  = 2
-indent_style = space
+charset                  = utf-8
+indent_size              = 2
+indent_style             = space
+trim_trailing_whitespace = true
 
 [*.js]
-indent_size  = 4
+indent_size              = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Tools not rules! Let’s make it really easy for people to do things properly—setting up a `.editorconfig` will ensure that correct formatting styles are applied free-of-charge.