### PR TITLE
Updated link styles

### DIFF
--- a/elements/_elements.details.scss
+++ b/elements/_elements.details.scss
@@ -26,6 +26,7 @@ details {
     color: $color-links;
     cursor: pointer;
     outline: none;
+    text-decoration-skip: ink;
 
     &:hover {
       color: $color-links-hover;

--- a/elements/_elements.details.scss
+++ b/elements/_elements.details.scss
@@ -26,11 +26,11 @@ details {
     color: $color-links;
     cursor: pointer;
     outline: none;
+    text-decoration: underline;
     text-decoration-skip: ink;
 
     &:hover {
       color: $color-links-hover;
-      text-decoration: underline;
     }
 
     &:active,
@@ -41,7 +41,7 @@ details {
     /* stylelint-disable selector-no-qualifying-type */
 
       details[open] > & {
-        color: #78be20;
+        color: #005eb8;
         text-decoration: underline;
       }
 

--- a/elements/_elements.links.scss
+++ b/elements/_elements.links.scss
@@ -5,10 +5,13 @@
 /**
  * This is simply to style bare A elements. Anything more complex should
  * probably become a Component.
+ *
+ * 1. Ensure that underlines don’t pass through descenders. Nice!
  */
 
 a {
   color: $color-links;
+  text-decoration-skip: ink; /* [1] */
 
   &:hover {
     color: $color-links-hover;

--- a/elements/_elements.links.scss
+++ b/elements/_elements.links.scss
@@ -49,30 +49,51 @@ a {
 
 /* Heading links
  *
- * A specific design style dictates that orphaned links in headers should look
- * like an H4. This is an attempt at that, but if it goes wrong then we need to
- * either remove or revisit it.
- *
- * 1. We’re using the `:only-child` selector here. AFAIK it has decent browser
- *    support, but if not we can proxy it by using the potentially better
- *    supported `:first-child:last-child` (because if something is both the
- *    first and the last child, it must be the only child).
+ * Links in headings look a little different
    ========================================================================== */
 
-// For terseness, let’s set up a block of placeholder declarations that we can
-// refer to later on. This is how we want only-links-in-headings to look.
-%_link-only-child {
-  @include font-size($global-font-size-h4);
+%_heading-link {
   text-decoration: none;
-  font-weight: bold;
+  color: $color-links-headings;
+}
+
+%_heading-link-visited {
+  text-decoration: underline;
+  color: $color-links-headings;
+}
+
+%_heading-link-hover {
+  text-decoration: underline;
+  color: $color-links-headings-hover;
+}
+
+%_heading-link-focus {
+  text-decoration: underline;
+  color: $color-links-headings;
 }
 
 // Loop through headings 1 through 6…
 @for $i from 1 through 6 {
 
   // …and recycle the declarations we left behind previously.
-  h#{$i} > a:only-child { /* [1] */
-    @extend %_link-only-child;
+  h#{$i} > a {
+
+    &:link {
+      @extend %_heading-link;
+    }
+
+    &:visited {
+      @extend %_heading-link-visited;
+    }
+
+    &:hover {
+      @extend %_heading-link-hover;
+    }
+
+    &:focus {
+      @extend %_heading-link-focus;
+    }
+
   }
 
 }

--- a/elements/_elements.links.scss
+++ b/elements/_elements.links.scss
@@ -13,6 +13,10 @@ a {
   color: $color-links;
   text-decoration-skip: ink; /* [1] */
 
+  &:visited {
+    color: $color-links-visited;
+  }
+
   &:hover {
     color: $color-links-hover;
   }
@@ -20,10 +24,6 @@ a {
   &:active,
   &:focus {
     color: $color-links-active;
-  }
-
-  &:visited {
-    color: $color-links-visited;
   }
 
   /* stylelint-disable selector-no-qualifying-type */

--- a/index.html
+++ b/index.html
@@ -101,6 +101,12 @@
 
         <h6><a href="#0">Heading Level Link 6</a></h6>
 
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. <a href="#0">Vestibulum tortor quam</a>,
+        feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero
+        sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+        placerat eleifend leo.</p>
+
         <ul class="c-color-grid">
           <li class="u-color-bg-attention"></li>
           <li class="u-color-bg-error"></li>

--- a/settings/_settings.colors.scss
+++ b/settings/_settings.colors.scss
@@ -25,10 +25,10 @@ $color-lists:   color('nhs-grey-dark') !default;
 // Links
 // ========================================================================== */
 
-$color-links:         color('nhs-purple')       !default;
-$color-links-hover:   color('nhs-purple-light') !default;
-$color-links-active:  color('nhs-orange')       !default;
-$color-links-visited: color('attention')        !default;
+$color-links:         color('nhs-purple') !default;
+$color-links-hover:   #8060a7             !default;
+$color-links-active:  color('nhs-blue')   !default;
+$color-links-visited: color('nhs-blue')   !default;
 
 $color-links-headings:       color('nhs-black') !default;
 $color-links-headings-hover: #646162            !default;

--- a/settings/_settings.colors.scss
+++ b/settings/_settings.colors.scss
@@ -30,6 +30,9 @@ $color-links-hover:   color('nhs-purple-light') !default;
 $color-links-active:  color('nhs-orange')       !default;
 $color-links-visited: color('attention')        !default;
 
+$color-links-headings:       color('nhs-black') !default;
+$color-links-headings-hover: #646162            !default;
+
 
 
 


### PR DESCRIPTION
I’ve implemented as much of the new link design styles as possible. There’s an odd quirk whereby `:visited` styles aren’t working in headings, but I don’t want that small issue to block progress.