### PR TITLE
[refs #00073] Style H5, H6 as H4

### DIFF
--- a/elements/_elements.headings.scss
+++ b/elements/_elements.headings.scss
@@ -21,7 +21,7 @@ h3 {
   font-weight: bold;
 }
 
-h4 {
+h4, h5, h6 {
   @include font-size($global-font-size-h4);
   font-weight: bold;
 }


### PR DESCRIPTION
The design specify no specific styles for H5 and H6 elements, so let’s
just make them behave like H4s. H4s all the way down.