### PR TITLE
[refs #00075] Lighten DETAILS colour

### DIFF
--- a/elements/_elements.details.scss
+++ b/elements/_elements.details.scss
@@ -7,6 +7,7 @@
  */
 
 details {
+  color: $color-details;
 
   /**
    * This is really far from ideal, but if we drop a DIV directly into the

--- a/settings/_settings.colors.scss
+++ b/settings/_settings.colors.scss
@@ -92,6 +92,7 @@ $color-ribbon-tag-bg:   color('nhs-black');
 // variables to style the majority of it.
 // ========================================================================== */
 
+$color-details:        color('nhs-grey-dark') !default;
 $color-details-border: color('nhs-grey-pale') !default;
 
 


### PR DESCRIPTION
The `details` element’s text colour was wrong.