### PR TITLE
[refs #00105] Move settings and tools imports into separate file

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -6,14 +6,10 @@
  * CONTENTS
  *
  * SETTINGS
- * Definitions..........Define constants such as font-sizes, etc.
- * Colors...............Apply our colors against variables.
- * Z-Index..............Set up an array of z-index values for developers to use.
+ * All..................Grab all of our settings files in one go.
  *
  * TOOLS
- * Functions............Simple functions to help us out with math, etc.
- * Mixins...............Basic, global mixins.
- * Sass MQ..............Elegant little mixins library.
+ * All..................Grab all of our tools files in one go.
  *
  * GENERIC
  * Box-sizing...........Better default box-sizing rules.
@@ -61,17 +57,13 @@
  * Display..............Show/hide/etc. utility classes.
  */
 
-@import "settings/settings.definitions";
-@import "settings/settings.colors";
-@import "settings/settings.z-index";
+@import "settings/all";
 
 
 
 
 
-@import "tools/tools.functions";
-@import "tools/tools.mixins";
-@import "sass-mq/mq";
+@import "tools/all";
 
 
 

--- a/settings/_all.scss
+++ b/settings/_all.scss
@@ -1,0 +1,16 @@
+// ==========================================================================
+// #SETTINGS
+// ========================================================================== */
+
+// CONTENTS
+//
+// Definitions..........Define constants such as font-sizes, etc.
+// Colors...............Apply our colors against variables.
+// Z-Index..............Set up an array of z-index values for developers to use.
+
+// By importing all of our settings here, we can utilise them directly in ITCSS
+// Isolated components later on much more easily.
+
+@import "settings/settings.definitions";
+@import "settings/settings.colors";
+@import "settings/settings.z-index";

--- a/tools/_all.scss
+++ b/tools/_all.scss
@@ -1,0 +1,16 @@
+// ==========================================================================
+// #TOOLS
+// ========================================================================== */
+
+// CONTENTS
+//
+// Functions............Simple functions to help us out with math, etc.
+// Mixins...............Basic, global mixins.
+// Sass MQ..............Elegant little mixins library.
+
+// By importing all of our tools here, we can utilise them directly in ITCSS
+// Isolated components later on much more easily.
+
+@import "tools/tools.functions";
+@import "tools/tools.mixins";
+@import "sass-mq/mq";


### PR DESCRIPTION
In order to enable the development of Isolated components, we need to be
able to arbitrarily `@import` our Settings and Tools layers into any
other file. To make this much more terse and less error-prone, I’ve
wrapped the individuals layers’ files in their own manifest file:
`{settings,tools}/_all.scss`.