### PR TITLE
[refs #000148] Separate h5 and h6 from h4

### DIFF
--- a/elements/_elements.headings.scss
+++ b/elements/_elements.headings.scss
@@ -21,7 +21,12 @@ h3 {
   font-weight: bold;
 }
 
-h4, h5, h6 {
+h4 {
   @include font-size($global-font-size-h4);
+  font-weight: bold;
+}
+
+h5, h6 {
+  @include font-size($global-font-size-h5);
   font-weight: bold;
 }

--- a/settings/_settings.definitions.scss
+++ b/settings/_settings.definitions.scss
@@ -37,6 +37,7 @@ $global-font-size-h1: 48px !default;
 $global-font-size-h2: 36px !default;
 $global-font-size-h3: 27px !default;
 $global-font-size-h4: 19px !default;
+$global-font-size-h5: 14px !default;
 
 
 


### PR DESCRIPTION
Because they're different font sizes.