### PR TITLE
[refs #00123] Disable modifier-based hints

### DIFF
--- a/utilities/_utilities.hints.scss
+++ b/utilities/_utilities.hints.scss
@@ -48,26 +48,4 @@ img:not([alt]) {
   @include _hint-error-styles();
 }
 
-
-
-
-
-/**
- * Certain elements without any additional classes are very unlikely to be
- * correct.
- */
-
-%_missing-modifier-error {
-  --error: "You probably need a Modifier on this elements’s Block.";
-  @include _hint-error-styles();
-}
-
-@each $class in c-btn, c-sprite {
-
-  .#{$class}:not([class*="#{$class}--"]) {
-    @extend %_missing-modifier-error;
-  }
-
-}
-
 } // endif


### PR DESCRIPTION
Because of an issue with `@extend`, we keep getting false positives with
the hints pertaining to missing modifiers. There’s no way around it
other than just removing them. Sucks :(