### PR TITLE
[refs #00146] Align nav items to vertical centres

### DIFF
--- a/components/nav-primary/_components.nav-primary.scss
+++ b/components/nav-primary/_components.nav-primary.scss
@@ -47,7 +47,7 @@
 
     .c-nav-primary__item {
       @include font-size(16px);
-      vertical-align: top;
+      vertical-align: middle;
 
       @include mq($from: md) {
         display: inline-block;


### PR DESCRIPTION
Rather than have nav links aligning to their tops, align them to their
middles.