### PR TITLE
[refs #00176] Add utility class to show white icon on dark background

### DIFF
--- a/elements/_elements.links.scss
+++ b/elements/_elements.links.scss
@@ -35,6 +35,10 @@ a {
       top: -1px;
     }
 
+    &.u-links-darkbg:after {
+      @include sprite(new-window-rev, true)
+    }
+
   /* stylelint-enable */
 
 }

--- a/index.html
+++ b/index.html
@@ -99,6 +99,27 @@
 
   </div>
 
+  <div class="c-ribbon  c-ribbon--alpha">
+
+    <div class="o-wrapper">
+
+      <strong class="c-ribbon__tag">Alpha</strong>
+
+      <strong class="c-ribbon__body">This page is part of a new service – your <a href="#0">feedback</a> will help us to improve it.</strong>
+
+    </div>
+
+  </div>
+
+<div class="c-ribbon" id="jsCookieRibbon">
+          <div class="o-wrapper">
+            <div class="c-ribbon__actions">
+              <button class="c-sprite  c-sprite--close-rev" id="jsCookieBtn">Close</button>
+            </div>
+            <strong class="c-ribbon__body">By default this site uses <a href="#" class="u-links-darkbg" target="_blank">cookies</a> to collect information and improve. To control cookies, you can <a href="#" class="u-links-darkbg" target="_blank">adjust your browser settings</a>.</strong>
+          </div>
+        </div>
+
   <header class="c-page-header" id="jsPageHeader">
 
     <div class="o-wrapper  c-page-header__inner">


### PR DESCRIPTION
This needs improvement but a starter for 10.

A utility class that can be used to reverse the colour of the
new-window icon when being used on dark backgrounds.

This feels wrong in many ways, a utility class in an element file and very specific to the new-window sprite. I wonder if we could make it more generic for reversing the sprite on dark backgrounds?

@csswizardry can you give an opinion, please?