### PR TITLE
[refs #00157] Restyle quotes

### DIFF
--- a/components/quotes/_components.quotes.scss
+++ b/components/quotes/_components.quotes.scss
@@ -1,0 +1,72 @@
+/* ==========================================================================
+   #QUOTES
+   ========================================================================== */
+
+/* Long-form quotations
+ *
+ * 1. The defined line-height for quotes elements is 32px, therefore we need to
+ *    grab the unitless line-height by calculating the ratio.
+ * 2. Remove leftover styling from BLOCKQUOTE element.
+   ========================================================================== */
+
+.c-quote {
+  $font-size: 24; // 1
+  position: relative;
+  @include font-size($font-size * 1px, 32/$font-size); // [1]
+  font-style: italic;
+  color: $color-quote;
+  padding-left: $global-spacing-unit-small;
+  margin-right: 0; /* [2] */
+  margin-left: 0; /* [2] */
+
+  /**
+   * 1. Slightly tighter spacing between quoted paragraphs.
+   */
+  > p {
+    margin-bottom: $global-spacing-unit-small; /* [1] */
+  }
+
+  /**
+   * This forms a faux `border-left`. Because we need the border to be
+   * effectively inset on reversed quotes, we remove it from document flow.
+   */
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    background-color: $color-quote-border;
+  }
+
+}
+
+  .c-quote__meta {
+    $font-size: 14;
+    @include font-size($font-size * 1px, 20/$font-size);
+    display: block;
+    text-align: right;
+    color: $color-quote-meta;
+    font-style: normal;
+
+    .c-quote--rev & {
+      color: $color-quote-alt;
+    }
+
+  }
+
+.c-quote--rev {
+  color: $color-quote-alt;
+  background-color: color('nhs-purple');
+  padding: $global-spacing-unit-small;
+  padding-left: $global-spacing-unit;
+
+  &:before {
+    border-color: $color-quote-alt;
+    top: $global-spacing-unit-small;
+    bottom: $global-spacing-unit-small;
+    left: $global-spacing-unit-small;
+  }
+
+}

--- a/elements/_elements.quotes.scss
+++ b/elements/_elements.quotes.scss
@@ -32,38 +32,11 @@ q {
 
 
 
-/* Standalone blockquotes
- *
- * 1. The defined line-height for BLOCKQUOTE elements is 32px, therefore we need
- *    to grab the unitless line-height by calculating the ratio.
+/* Blockquotes
    ========================================================================== */
 
 blockquote {
-
-  // How many times bigger than the text should the hung quote be?
-  $hung-quote-ratio: 3;
-
-  @include font-size(24px, 32/24);
   font-style: italic;
-  color: #425563;
-  padding-left: $hung-quote-ratio * 1em;
-
-  /**
-   * Blockquotes have a hung quote as a visual decoration. A lot of the values
-   * below have been eyeballed, so they’re kinda subjective. The size of the
-   * quote mark is sourced from `$hung-quote-ratio`, above. We also use this
-   * value to work out how much space to reserve around the text itself.
-   */
-  &:before {
-    content: "“";
-    float: left;
-    font-size: $hung-quote-ratio * 1em;
-    line-height: 1;
-    width: 1em;
-    text-align: center;
-    margin-left: -1em;
-    position: relative;
-    top: -4px;
-  }
-
+  margin-right: $global-spacing-unit;
+  margin-left: $global-spacing-unit;
 }

--- a/index.html
+++ b/index.html
@@ -416,6 +416,29 @@
 
         <hr class="c-divider" />
 
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
+
+        <blockquote class="uote">
+          <p>Many centuries ago, man was able to tell the time by looking at the
+          sun and its position in the sky. Then came the sundial and finally
+          clocks and watches.</p>
+          <span class="uote__meta">
+            <b>Quote author</b><br />
+            Author role<br />
+            Organisation
+          </span>
+        </blockquote>
+
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
+
         <h2 id="media">Media</h2>
 
         <figure class="c-media">
@@ -1144,9 +1167,26 @@
 
         <h2 id="quotes">Quotes</h2>
 
-        <blockquote>
-          <p>Pellentesque habitant morbi tristique senectus et netus et
-          malesuada.</p>
+        <blockquote class="c-quote">
+          <p>Many centuries ago, man was able to tell the time by looking at the
+          sun and its position in the sky. Then came the sundial and finally
+          clocks and watches.</p>
+          <span class="c-quote__meta">
+            <b>Quote author</b><br />
+            Author role<br />
+            Organisation
+          </span>
+        </blockquote>
+
+        <blockquote class="c-quote  c-quote--rev">
+          <p>Many centuries ago, man was able to tell the time by looking at the
+          sun and its position in the sky. Then came the sundial and finally
+          clocks and watches.</p>
+          <span class="c-quote__meta">
+            <b>Quote author</b><br />
+            Author role<br />
+            Organisation
+          </span>
         </blockquote>
 
         <hr class="c-divider" />

--- a/main.scss
+++ b/main.scss
@@ -46,6 +46,7 @@
  * Progress Bar.........Linear progress bar
  * Progress Wheel.......Circular progress indicator
  * Forms................All of our different form styles.
+ * Quotes...............Quotations.
  * Comments.............Comment and discussion threads.
  * Pagination...........Component for paging through items/views.
  * Tabs.................Tabbed content switcher.
@@ -120,6 +121,7 @@
 @import "components/progress/components.progress-bar";
 @import "components/progress/components.progress-wheel";
 @import "components/forms/components.forms";
+@import "components/quotes/components.quotes";
 @import "components/comments/components.comments";
 @import "components/pagination/components.pagination";
 @import "components/tabs/components.tabs";

--- a/settings/_settings.colors.scss
+++ b/settings/_settings.colors.scss
@@ -255,3 +255,16 @@ $color-breadcrumb:    color('nhs-black') !default;
 
 $color-comments-border: color('nhs-grey-pale') !default;
 $color-comments-link: color('nhs-blue') !default;
+
+
+
+
+
+// Quotes
+// ========================================================================== */
+
+$color-quote:        color('nhs-grey-dark') !default;
+$color-quote-meta:   color('nhs-black')     !default;
+$color-quote-border: color('nhs-grey-pale') !default;
+$color-quote-alt:    color('white')         !default;
+$color-quote-alt-bg: color('nhs-purple')    !default;


### PR DESCRIPTION
As far as I can tell, this is ready to merge.

Following @csswizardry's update, quotes have gone from this:
![screen shot 2018-01-29 at 15 22 57](https://user-images.githubusercontent.com/1991226/35518068-59081efc-0508-11e8-9dbd-3510e10ac2b4.png)

To this:
![screen shot 2018-01-29 at 15 23 46](https://user-images.githubusercontent.com/1991226/35518102-70fbb5dc-0508-11e8-8ee4-c6aae66460e5.png)
