### PR TITLE
[refs #00202] Put link descriptions into <p> tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,15 +209,15 @@
     <div class="o-layout  o-layout--wide">
       <div class="o-layout__item  u-4/12@lg">
         <h3><a href="/">Open now</a></h3>
-        For every level of leadership
+        <p>For every level of leadership</p>
       </div><!-- o-layout__item -->
       <div class="o-layout__item  u-4/12@lg">
         <h3><a href="/">Share your story</a></h3>
-        From our Participants
+        <p>From our Participants</p>
       </div><!-- o-layout__item -->
       <div class="o-layout__item  u-4/12@lg">
         <h3><a href="/">Our programmes</a></h3>
-        Academies nationwide
+        <p>Academies nationwide</p>
       </div><!-- o-layout__item -->
     </div><!-- o-layout -->
 


### PR DESCRIPTION
On homepage links, put descriptions into paragraphs so they have space below them.

<img width="988" alt="screen shot 2018-04-04 at 17 05 40" src="https://user-images.githubusercontent.com/1991226/38319743-79bb4d22-382a-11e8-94c2-a7868c61ec74.png">
