### PR TITLE
[refs #00201] Larger font for leading paragraphs

### DIFF
--- a/components/paragraphs/_components.leading-paragraph.scss
+++ b/components/paragraphs/_components.leading-paragraph.scss
@@ -1,0 +1,12 @@
+/* ==========================================================================
+   #LEADING-PARAGRAPH
+   ========================================================================== */
+
+/**
+ * Larger font size for the first paragraph on a page/post.
+ *
+ */
+
+.c-leading-paragraph {
+  font-size: $global-font-size-leading-paragraph;
+}

--- a/components/paragraphs/_components.leading-paragraph.scss
+++ b/components/paragraphs/_components.leading-paragraph.scss
@@ -9,4 +9,5 @@
 
 .c-leading-paragraph {
   font-size: $global-font-size-leading-paragraph;
+  line-height: $global-line-height-leading-paragraph;
 }

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
 
     <h1>Nightingale</h1>
 
-    <p>Welcome to the NHS Leadership Academy UI Toolkit and front-end
+    <p class="c-leading-paragraph">Welcome to the NHS Leadership Academy UI Toolkit and front-end
     framework, codename <b>Nightingale</b>.</p>
 
     <hr class="c-divider" />

--- a/main.scss
+++ b/main.scss
@@ -56,6 +56,7 @@
  * Tables...............More complex styles for data tables
  * Search...............Search box for header.
  * Articles.............Styling for blog posts/articles.
+ * Leading Paragraph....Larger font size for leading paragraphs.
  *
  * UTILITIES
  * Colors...............Utility classes generated from our color map.
@@ -133,7 +134,7 @@
 @import "components/tables/components.tables";
 @import "components/search/components.search";
 @import "components/articles/components.articles";
-
+@import "components/paragraphs/components.leading-paragraph";
 
 
 

--- a/settings/_settings.definitions.scss
+++ b/settings/_settings.definitions.scss
@@ -39,7 +39,7 @@ $global-font-size-h3: 27px !default;
 $global-font-size-h4: 19px !default;
 $global-font-size-h5: 14px !default;
 
-
+$global-font-size-leading-paragraph: 24px !default;
 
 
 

--- a/settings/_settings.definitions.scss
+++ b/settings/_settings.definitions.scss
@@ -40,6 +40,7 @@ $global-font-size-h4: 19px !default;
 $global-font-size-h5: 14px !default;
 
 $global-font-size-leading-paragraph: 24px !default;
+$global-line-height-leading-paragraph: 32px !default;
 
 
 


### PR DESCRIPTION
I have added a definition and style for leading paragraphs so they can be displayed at the larger font-size of 24px.

<img width="997" alt="screen shot 2018-04-05 at 10 42 52" src="https://user-images.githubusercontent.com/1991226/38358833-4d257456-38be-11e8-8ab3-30e19f4875ac.png">
