### PR TITLE
[refs #00224] Fix double heading border

### DIFF
--- a/components/breadcrumb/_components.breadcrumb.scss
+++ b/components/breadcrumb/_components.breadcrumb.scss
@@ -8,6 +8,7 @@
  * 1. Make sure all browsers scroll to the best of their abilities.
  * 2. Native-like scrolling on touch devices.
  * 3. Use negative top margin to negate bottom margin of header this is under.
+ * 4. Use larger top margin if breacrumbs sit under page-specific ribbons.
  */
 .c-breadcrumb {
   @include font-size(14px);
@@ -19,13 +20,15 @@
   -webkit-overflow-scrolling: touch; /* [2] */
   background-color: $color-breadcrumb-bg;
   padding: $global-spacing-unit-tiny;
-  margin-top: -($global-spacing-unit + $global-border-mid); /* [3] */
+  margin-top: -$global-spacing-unit; /* [3] */
   margin-left: -$global-spacing-unit;
   margin-right: -$global-spacing-unit;
   padding-left: $global-spacing-unit;
   padding-right: $global-spacing-unit;
 }
-
+.c-ribbon--page-specific + .c-breadcrumb {
+  margin-top: -($global-spacing-unit + $global-border-mid); /* [4] */
+}
   .c-breadcrumb__list {
     margin-left: 0;
     margin-bottom: 0;

--- a/components/page-header/_components.page-header.scss
+++ b/components/page-header/_components.page-header.scss
@@ -37,6 +37,7 @@
     bottom: -($global-border-mid + $global-border-heavy);
     left: 0;
     border-bottom: $global-border-mid solid color('nhs-purple');
+    display: block;
   }
 
   @include mq($from: md) {

--- a/components/page-header/_components.page-header.scss
+++ b/components/page-header/_components.page-header.scss
@@ -37,7 +37,7 @@
     bottom: -($global-border-mid + $global-border-heavy);
     left: 0;
     border-bottom: $global-border-mid solid color('nhs-purple');
-    display: block;
+    display: block; // Temporary fix. See Nightingale issue #229
   }
 
   @include mq($from: md) {

--- a/components/ribbons/_components.ribbons.scss
+++ b/components/ribbons/_components.ribbons.scss
@@ -33,6 +33,7 @@
 
 .c-ribbon--page-specific {
   margin-top: -($global-spacing-unit + $global-border-mid); /* [1] */
+  margin-top: -$global-spacing-unit; /* [1] */
   margin-bottom: $global-spacing-unit + $global-border-mid; /* [1] */
   margin-left: -$global-spacing-unit;
   margin-right: -$global-spacing-unit;


### PR DESCRIPTION
Following an earlier update, the faux bottom border was no longer being
displayed. I investigated and it was being displayed as a table so I changed it to block.