### PR TITLE
[refs #00234] Move purple tint to own class

### DIFF
--- a/components/media/_components.media.scss
+++ b/components/media/_components.media.scss
@@ -18,11 +18,13 @@
   /**
    * Media with mastheads that contain media (e.g. an image).
    */
-  .c-media__masthead {
-    position: relative;
-    display: block;
-    border: 1px solid $color-media-border;
+   .c-media__masthead {
+     position: relative;
+     display: block;
+     border: 1px solid $color-media-border;
+   }
 
+  .c-media__masthead--overlay {
     /**
      * Translucent overlay covering the media.
      */
@@ -47,9 +49,9 @@
   }
 
     /**
-     * Media media itself needs dimming.
+     * If overlay is applied media itself needs dimming.
      */
-    .c-media__media {
+    .c-media__media--overlay {
       opacity: 0.3;
       width: 100%;
 

--- a/index.html
+++ b/index.html
@@ -552,11 +552,11 @@
 
         <figure class="c-media">
 
-          <div class="c-media__masthead">
-            <img src="./assets/img/content/photo.jpg" alt="" class="c-media__media" />
+          <div class="c-media__masthead  c-media__masthead--overlay">
+            <img src="./assets/img/content/photo.jpg" alt="" class="c-media__media--overlay" />
           </div>
 
-          <figcaption class="c-media__content">Image: Image description tag here</figcaption>
+          <figcaption class="c-media__content">Image with overlay</figcaption>
 
         </figure>
 


### PR DESCRIPTION
So we can control which media has an overlay rather than making it standard for all media.

In screenshot below, top images is plain and bottom one has an overlay:

![screen shot 2018-05-22 at 11 42 51](https://user-images.githubusercontent.com/1991226/40357875-6891129c-5db5-11e8-890c-fbcc10d8395e.png)
