### PR TITLE
[refs #00223] Give all HX elements smaller margins

### DIFF
--- a/generic/_generic.shared.scss
+++ b/generic/_generic.shared.scss
@@ -11,7 +11,6 @@
 
 address,
 details,
-h1, h2, h3, h4, h5, h6,
 blockquote, p, pre,
 dl, ol, ul,
 figure,
@@ -19,6 +18,10 @@ hr,
 table,
 fieldset {
   @include rem(margin-bottom, $global-spacing-unit);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  @include rem(margin-bottom, $global-spacing-unit-small);
 }
 
 ul, ol,

--- a/index.html
+++ b/index.html
@@ -1282,15 +1282,51 @@
 
         <h1>Heading Level 1</h1>
 
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
+
         <h2>Heading Level 2</h2>
+
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
 
         <h3>Heading Level 3</h3>
 
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
+
         <h4>Heading Level 4</h4>
+
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
 
         <h5>Heading Level 5</h5>
 
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
+
         <h6>Heading Level 6</h6>
+
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae,
+        ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam
+        egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend
+        leo.</p>
 
         <h1><a href="#0">Heading Level Link 1</a></h1>
 

--- a/settings/_settings.definitions.scss
+++ b/settings/_settings.definitions.scss
@@ -35,19 +35,24 @@ $global-line-height:      26px !default;
 
 $global-font-size-h1:     48px !default;
 $global-line-height-h1:   58px !default;
+
 $global-font-size-h2:     36px !default;
 $global-line-height-h2:   44px !default;
+
 $global-font-size-h3:     24px !default;
 $global-line-height-h3:   29px !default;
+
 $global-font-size-h4:     18px !default;
 $global-line-height-h4:   22px !default;
+
 $global-font-size-h5:     16px !default;
 $global-line-height-h5:   19px !default;
+
 $global-font-size-h6:     14px !default;
 $global-line-height-h6:   17px !default;
 
 
-$global-font-size-leading-paragraph: 24px !default;
+$global-font-size-leading-paragraph:   24px !default;
 $global-line-height-leading-paragraph: 32px !default;
 
 $global-font-size-footer: 14px !default;


### PR DESCRIPTION
By default, H1–6 elements carried a 30px margin-bottom; we’ve now
changed it to be 15px.