### PR TITLE
DI-104 Non Integer values generated in scss files

### DIFF
--- a/tools/_tools.functions.scss
+++ b/tools/_tools.functions.scss
@@ -60,3 +60,7 @@
   @return $map;
 
 }
+
+@function get-line-height($font-size, $line-height) {
+  @return $line-height / $font-size;
+}

--- a/tools/_tools.mixins.scss
+++ b/tools/_tools.mixins.scss
@@ -72,8 +72,8 @@
 
     @else if ($line-height != none and $line-height != false) {
 
-      @warn "`#{$line-height}` is not a valid value for `line-height`.";
-
+      //@warn "`#{$line-height}` is not a valid value for `line-height`.";
+      line-height: get-line-height($font-size, $line-height);
     }
 
   }


### PR DESCRIPTION
Added new function to _tools.functions:
 - @function get-line-height($font-size, $line-height)
Modified _tools.mixins:
 - Commented out warn message line 75 for non integer and non blank values
 - replaced with line 76 that generates a value based on new function