### PR TITLE
[refs #00271] Remove Safari Repaint Hack

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,23 +1648,5 @@
 
   </footer>
 
-  <script>
-    // Eww, eww, ewwww! Forcing a repaint to get around a really, really odd
-    // Safari bug: https://twitter.com/csswizardry/status/897110955448029184
-    (function(){
-      var ua = navigator.userAgent.toLowerCase();
-      if (ua.indexOf('safari') != -1) {
-        if (ua.indexOf('chrome') > -1) {
-        } else {
-          function ready() {
-            var page = document.getElementById('jsPage');
-            page.style.color = '#231f21';
-          };
-          document.addEventListener("DOMContentLoaded", ready);
-        }
-      }
-    }());
-  </script>
-
 </body>
 </html>


### PR DESCRIPTION
Safari exhibited an unusual bug whereby any rem-sized text appearing
anywhere after a DETAILS element was rendered impossibly small. Like,
1px kinda size. The/a way of getting around it was to force a full-page
repaint, which is icky, but it was scoped to only Safari users.

Anyway! Good news is that the bug has been fixed[1] so we can delete the
hack, which is nice.

1. https://bugs.webkit.org/show_bug.cgi?id=173876